### PR TITLE
docs: align sensor adhesive guide with 4070 (60–100°C) and HY 4090 (>…

### DIFF
--- a/docs/predict/hardware-setup/sensor-gateway-install-sop.md
+++ b/docs/predict/hardware-setup/sensor-gateway-install-sop.md
@@ -65,7 +65,8 @@ Before beginning installation:
 
 ### Adhesive
 - [ ] **[Loctite 454](https://docs.rs-online.com/86cf/0900766b801dff4e.pdf)** – For flat surfaces (general use)
-- [ ] **[Loctite 4070](https://techsil.s3.eu-west-2.amazonaws.com/TE/TDS/HECY50040-tds.pdf)** – For curved surfaces and high temperature applications (+80°C)
+- [ ] **[Loctite 4070](https://techsil.s3.eu-west-2.amazonaws.com/TE/TDS/HECY50040-tds.pdf)** – Excellent for **60–100°C** surface or operating temperature at the mount (including curved surfaces in this temperature band)
+- [ ] **[Loctite HY 4090](https://datasheets.tdx.henkel.com/LOCTITE-HY-4090-en_GL.pdf)** – Best suited when surface or operating temperature **exceeds 100°C**; two-part dual-cartridge product—follow manufacturer mixing and application instructions
 
 ### Hardware
 - [ ] Sensors (as per installation plan)
@@ -240,7 +241,7 @@ Complete gateway installation first to ensure sensors can connect immediately af
 | Gateway shows offline | Network connectivity issue | Power cycle the gateway. Check WiFi/Ethernet connection. Verify SSID and password. |
 | Gateway LED is solid green or slow orange flash | Not connected to cloud | Check modem/network connectivity. Power cycle gateway. |
 | Sensor not appearing in app | Out of range, gateway offline, or sensor not activated | Ensure gateway is online. Verify sensor is within 20m of gateway. Wait up to 1 hour for initial sync. |
-| Sensor won't stay mounted | Surface not clean or wrong adhesive type | Remove sensor, re-clean surface, use appropriate adhesive for surface type. |
+| Sensor won't stay mounted | Surface not clean or wrong adhesive type or temperature band | Remove sensor, re-clean surface. Use adhesive matched to surface geometry and to the mount-point temperature (4070 for 60–100°C, HY 4090 above 100°C; see Required Materials). |
 | Weak sensor signal | Obstruction or distance | Relocate gateway closer or install additional gateway. |
 
 ---

--- a/docs/predict/hardware-setup/sensor-install-guide.mdx
+++ b/docs/predict/hardware-setup/sensor-install-guide.mdx
@@ -40,10 +40,16 @@ In some cases, space constraints prevent ideal sensor placement on machines like
 ![Example 4 with a small motor and fan](img/DSC_9423%20Medium.jpeg)
 
 ## Adhesive
-We recommend using three types of loctite.
-- Flat surfaces: Loctite 454
-- Slightly curved surfaces: Loctite 3090
-- High temperature (+80ºC) applications: Loctite 4070
+We recommend using Loctite products matched to the surface and to **surface or operating temperature** at the mount point:
+
+- **Flat surfaces:** Loctite 454
+- **Slightly curved surfaces:** Loctite 3090
+- **60–100°C:** Loctite 4070 — excellent in this range (including curved or high-temperature installs within it)
+- **Exceeding 100°C:** Loctite HY 4090 — best suited for high-temperature installs; follow Henkel dual-cartridge mixing and application instructions (differs from single-part adhesives in the video below)
+
+:::note
+The install video demonstrates **single-part** adhesives (e.g. 454, 3090, 4070). **HY 4090** is a two-part product: use the supplied mixer nozzle and manufacturer directions.
+:::
 
 ## Installation Steps
 
@@ -58,7 +64,7 @@ We recommend using three types of loctite.
     1. Is there enough space?
     2. Is there enough contact between sensor and machine? particularly for curved surfaces
     3. Check the orientation of the sensor - x,y,z (marked on the sensor itself)
-4. Apply Loctite sparing on the underside of the sensor, avoiding the metal circle in the middle (temperature sensor) - see video for further guidance.
+4. Apply the **selected** Loctite (per [Adhesive](#adhesive) above) sparingly on the underside of the sensor, avoiding the metal circle in the middle (temperature sensor)—see video for single-part products; use manufacturer instructions for HY 4090.
 5. Affix sensor to the surface, holding the sensor for 15-30 seconds (depending on whether the surface is curved)
 6. **Factory AI** will verify whether the sensor can connect to the gateway
 


### PR DESCRIPTION
…100°C)

Update the sensor install guide and gateway install SOP so high-temperature mounts use Loctite HY 4090 above 100°C and 4070 for the 60–100°C band. Add HY 4090 two-part application note, TDS link, and troubleshooting hint.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b122d2165b22bf82dc78162c98b2b0e12a2eb9bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->