### PR TITLE
docs: start sensor glue video muted by default

### DIFF
--- a/docs/predict/hardware-setup/sensor-install-guide.mdx
+++ b/docs/predict/hardware-setup/sensor-install-guide.mdx
@@ -68,4 +68,4 @@ The install video demonstrates **single-part** adhesives (e.g. 454, 3090, 4070).
 5. Affix sensor to the surface, holding the sensor for 15-30 seconds (depending on whether the surface is curved)
 6. **Factory AI** will verify whether the sensor can connect to the gateway
 
-<ReactPlayer playing controls url='/sensor-glue.mov' />
+<ReactPlayer playing muted controls url='/sensor-glue.mov' />


### PR DESCRIPTION
Adds `muted` to ReactPlayer on the sensor install guide so the glue video autoplays without background noise; viewers can unmute via the player controls.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that just adjusts embedded video player behavior; no production logic or data/auth paths affected.
> 
> **Overview**
> Updates the sensor install guide to render the embedded glue instruction video with `muted` enabled, allowing autoplay without audio while keeping user controls to unmute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b7d65eeaeb5ddc61f786c3c9fb11abadc630aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->